### PR TITLE
sensorservice: customize sensor fusion mag filter via prop

### DIFF
--- a/services/sensorservice/Fusion.h
+++ b/services/sensorservice/Fusion.h
@@ -60,6 +60,11 @@ class Fusion {
      */
     mat<mat33_t, 2, 2> GQGt;
 
+    /**
+     * the maximum acceptable geomagnetic-field (square)
+     */
+    float maxValidMagFieldSq;
+
 public:
     Fusion();
     void init(int mode = FUSION_9AXIS);


### PR DESCRIPTION
When large magnetic fields values get filtered out by the Sensor
Fusion algorithm the fused sensors (rotation vector, gravity, linear
acceleration etc) do not produce any output. As a result the CTS tests
fail if the compass is uncalibrated on some devices.

This change allows the magnetic field filter to be tweaked on a
per-device basis to allow the fused sensors to operate even when the
compass in uncalibrated.

Change-Id: I608b307e8b7712e806315a6181c19130ec17c847